### PR TITLE
feat: Test DisplayName 설정 및 중복 좋아요 등록 시도 에러 처리 추가

### DIFF
--- a/src/main/java/woori_design_web/backend_woori_design_web/service/impl/UserLikeServiceImpl.java
+++ b/src/main/java/woori_design_web/backend_woori_design_web/service/impl/UserLikeServiceImpl.java
@@ -19,11 +19,24 @@ import java.time.LocalDateTime;
 public class UserLikeServiceImpl implements UserLikeService {
     private final UserLikeRepository userLikeRepository;
 
+    /** 공통 입력값 검증 메서드 */
+    private void validateInput(Long userId, Long postId) {
+        if (userId == null || postId == null) {
+            log.error("❌ User ID 또는 Post ID는 null일 수 없습니다.");
+            throw new IllegalArgumentException("❌ User ID 또는 Post ID는 null일 수 없습니다.");
+        }
+    }
+
     /** 좋아요 등록 */
     @Override
     @Transactional
     public UserLikeDto addLike(Long userId, Long postId) {
         validateInput(userId, postId);
+
+        if (userLikeRepository.findByUserIdAndPostId(userId, postId).isPresent()) {
+            log.warn("❌ 중복 좋아요 등록 시도 - userId: {}, postId: {}", userId, postId);
+            throw new IllegalStateException("🚀 중복 좋아요 등록 시도 - userId: " + userId + ", postId: " + postId);
+        }
 
         UserLike userLike = UserLike.builder()
                 .user(User.builder().id(userId).build())
@@ -68,11 +81,4 @@ public class UserLikeServiceImpl implements UserLikeService {
         return likeCount != null ? likeCount : 0L;
     }
 
-    /** 공통 입력값 검증 메서드 */
-    private void validateInput(Long userId, Long postId) {
-        if (userId == null || postId == null) {
-            log.error("❌ User ID 또는 Post ID는 null일 수 없습니다.");
-            throw new IllegalArgumentException("❌ User ID 또는 Post ID는 null일 수 없습니다.");
-        }
-    }
 }

--- a/src/test/java/woori_design_web/backend_woori_design_web/service/impl/UserLikeServiceImplTest.java
+++ b/src/test/java/woori_design_web/backend_woori_design_web/service/impl/UserLikeServiceImplTest.java
@@ -1,7 +1,9 @@
 package woori_design_web.backend_woori_design_web.service.impl;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,6 +14,7 @@ import woori_design_web.backend_woori_design_web.entity.User;
 import woori_design_web.backend_woori_design_web.entity.UserLike;
 import woori_design_web.backend_woori_design_web.repository.UserLikeRepository;
 
+import java.io.Console;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -31,6 +34,11 @@ class UserLikeServiceImplTest {
     private UserLike userLike;
     private UserLikeDto userLikeDto;
 
+    @BeforeAll
+    static void beforeAll() {
+        System.out.println("🛠 테스트 시작!");
+    }
+
     @BeforeEach
     void setUp() {
         user = User.builder().id(1L).build();
@@ -41,8 +49,8 @@ class UserLikeServiceImplTest {
         userLikeDto = new UserLikeDto(userLike);
     }
 
-    /** ✅ 좋아요 등록 테스트 (DTO 반환 확인) */
     @Test
+    @DisplayName("좋아요 등록 테스트")
     void testAddLike() {
         when(userLikeRepository.save(any(UserLike.class))).thenReturn(userLike);
 
@@ -54,8 +62,8 @@ class UserLikeServiceImplTest {
         verify(userLikeRepository, times(1)).save(any(UserLike.class));
     }
 
-    /** ✅ 좋아요 삭제 테스트 */
     @Test
+    @DisplayName("좋아요 삭제 테스트")
     void testRemoveLike() {
         when(userLikeRepository.findByUserIdAndPostId(1L, 100L)).thenReturn(Optional.of(userLike));
         doNothing().when(userLikeRepository).delete(userLike);
@@ -64,8 +72,8 @@ class UserLikeServiceImplTest {
         verify(userLikeRepository, times(1)).delete(userLike);
     }
 
-    /** ✅ 특정 postId의 좋아요 개수 조회 테스트 */
     @Test
+    @DisplayName("특정 컴포넌트(postId)의 좋아요 개수 조회 테스트")
     void testGetLikeCountByPostId() {
         when(userLikeRepository.existsByPostId(100L)).thenReturn(true);
         when(userLikeRepository.countLikesByPostId(100L)).thenReturn(3L);
@@ -76,8 +84,8 @@ class UserLikeServiceImplTest {
         assertEquals(3L, likeCount);
     }
 
-    /** ✅ 존재하지 않는 postId로 좋아요 개수 조회 시 예외 발생 테스트 */
     @Test
+    @DisplayName("존재하지 않는 postId로 좋아요 개수 조회 시, 예외 처리 테스트")
     void testGetLikeCountByPostId_NotFound() {
         when(userLikeRepository.existsByPostId(999L)).thenReturn(false);
 
@@ -88,18 +96,8 @@ class UserLikeServiceImplTest {
         assertEquals("해당 postId에 대한 좋아요 기록이 없습니다.", exception.getMessage());
     }
 
-    /** ✅ 유효하지 않은 User ID로 좋아요 등록 시 예외 발생 테스트 */
     @Test
-    void testAddLikeWithInvalidUser() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            userLikeService.addLike(null, 100L);
-        });
-
-        assertEquals("❌ User ID 또는 Post ID는 null일 수 없습니다.", exception.getMessage());
-    }
-
-    /** ✅ 존재하지 않는 좋아요 삭제 시 예외 발생 테스트 */
-    @Test
+    @DisplayName("존재하지 않는 좋아요 삭제 시, 예외 처리 테스트")
     void testRemoveLikeWithInvalidPost() {
         when(userLikeRepository.findByUserIdAndPostId(1L, 999L)).thenReturn(Optional.empty());
 
@@ -109,4 +107,29 @@ class UserLikeServiceImplTest {
 
         assertEquals("해당 좋아요가 존재하지 않습니다.", exception.getMessage());
     }
+
+    @Test
+    @DisplayName("유효하지 않은 userId로 좋아요 등록 시, 예외 처리 테스트")
+    void testAddLikeWithInvalidUser() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            userLikeService.addLike(null, 100L);
+        });
+
+        assertEquals("❌ User ID 또는 Post ID는 null일 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("같은 userId가 동일한 postId에 대해 중복 좋아요 시도 시 예외 처리 테스트")
+    void testAddLikeWithDuplicateUser() {
+        when(userLikeRepository.findByUserIdAndPostId(1L, 100L)).thenReturn(Optional.of(userLike));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+            userLikeService.addLike(1L, 100L);
+        });
+
+        assertEquals("🚀 중복 좋아요 등록 시도 - userId: 1, postId: 100", exception.getMessage());
+
+        verify(userLikeRepository, never()).save(any(UserLike.class));
+    }
+
 }


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🔗 관련 이슈 링크
Close # ❌

## 💜 개요
- 현식님이 말해주신 Test DisplayName 설정 및 중복 좋아요 등록 시도 에러 처리 추가 작업을 하였습니다.

## 🔁 변경 사항
```java
    @Test
    @DisplayName("같은 userId가 동일한 postId에 대해 중복 좋아요 시도 시 예외 처리 테스트")
    void testAddLikeWithDuplicateUser() {
        when(userLikeRepository.findByUserIdAndPostId(1L, 100L)).thenReturn(Optional.of(userLike));

        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
            userLikeService.addLike(1L, 100L);
        });

        assertEquals("🚀 중복 좋아요 등록 시도 - userId: 1, postId: 100", exception.getMessage());

        verify(userLikeRepository, never()).save(any(UserLike.class));
    }
```

## 📸 스크린샷 (선택)
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/f6976e6f-cdba-4982-937e-f8f3c54e419f" />
